### PR TITLE
Changes for pubstwo-jira-1671 (Storing short form oricid in database):

### DIFF
--- a/src/main/java/gov/usgs/cida/pubs/busservice/PersonContributorBusService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/PersonContributorBusService.java
@@ -5,7 +5,7 @@ import gov.usgs.cida.pubs.domain.Contributor;
 import gov.usgs.cida.pubs.domain.OutsideContributor;
 import gov.usgs.cida.pubs.domain.PersonContributor;
 import gov.usgs.cida.pubs.domain.UsgsContributor;
-import gov.usgs.cida.pubs.utility.DataNormalization;
+import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 
 import java.util.Set;
 
@@ -46,7 +46,7 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 				Contributor<PersonContributor<UsgsContributor>> uc = (UsgsContributor) object;
 				uc.setValidationErrors(validator.validate(uc));
 			}
-			DataNormalization.normalize(object);
+			DataNormalizationUtils.normalize(object);
 			if (object.isValid()) {
 				updateAffiliations(id, object);
 				PersonContributor.getDao().update(object);
@@ -70,7 +70,7 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 				Set<ConstraintViolation<Contributor<PersonContributor<UsgsContributor>>>> results = validator.validate(uc);
 				uc.setValidationErrors(results);
 			}
-			DataNormalization.normalize(result);
+			DataNormalizationUtils.normalize(result);
 			if (result.isValid()) {
 				Integer id = PersonContributor.getDao().add(result);
 				updateAffiliations(id, result);

--- a/src/main/java/gov/usgs/cida/pubs/busservice/PersonContributorBusService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/PersonContributorBusService.java
@@ -5,6 +5,7 @@ import gov.usgs.cida.pubs.domain.Contributor;
 import gov.usgs.cida.pubs.domain.OutsideContributor;
 import gov.usgs.cida.pubs.domain.PersonContributor;
 import gov.usgs.cida.pubs.domain.UsgsContributor;
+import gov.usgs.cida.pubs.utility.DataNormalization;
 
 import java.util.Set;
 
@@ -45,6 +46,7 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 				Contributor<PersonContributor<UsgsContributor>> uc = (UsgsContributor) object;
 				uc.setValidationErrors(validator.validate(uc));
 			}
+			DataNormalization.normalize(object);
 			if (object.isValid()) {
 				updateAffiliations(id, object);
 				PersonContributor.getDao().update(object);
@@ -58,7 +60,7 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 	@Transactional
 	public PersonContributor<?> createObject(PersonContributor<?> object) {
 		PersonContributor<?> result = object;
-		if (null != object) {
+		if (null != result) {
 			if (result instanceof OutsideContributor) {
 				Contributor<PersonContributor<OutsideContributor>> oc = (OutsideContributor) result;
 				Set<ConstraintViolation<Contributor<PersonContributor<OutsideContributor>>>> results = validator.validate(oc);
@@ -68,9 +70,10 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 				Set<ConstraintViolation<Contributor<PersonContributor<UsgsContributor>>>> results = validator.validate(uc);
 				uc.setValidationErrors(results);
 			}
+			DataNormalization.normalize(result);
 			if (result.isValid()) {
 				Integer id = PersonContributor.getDao().add(result);
-				updateAffiliations(id, object);
+				updateAffiliations(id, result);
 				result = (PersonContributor<?>) PersonContributor.getDao().getById(id);
 			}
 		}
@@ -89,4 +92,5 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 			}
 		}
 	}
+
 }

--- a/src/main/java/gov/usgs/cida/pubs/busservice/PersonContributorBusService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/PersonContributorBusService.java
@@ -5,7 +5,6 @@ import gov.usgs.cida.pubs.domain.Contributor;
 import gov.usgs.cida.pubs.domain.OutsideContributor;
 import gov.usgs.cida.pubs.domain.PersonContributor;
 import gov.usgs.cida.pubs.domain.UsgsContributor;
-import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 
 import java.util.Set;
 
@@ -46,7 +45,6 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 				Contributor<PersonContributor<UsgsContributor>> uc = (UsgsContributor) object;
 				uc.setValidationErrors(validator.validate(uc));
 			}
-			DataNormalizationUtils.normalize(object);
 			if (object.isValid()) {
 				updateAffiliations(id, object);
 				PersonContributor.getDao().update(object);
@@ -70,7 +68,6 @@ public class PersonContributorBusService extends BusService<PersonContributor<?>
 				Set<ConstraintViolation<Contributor<PersonContributor<UsgsContributor>>>> results = validator.validate(uc);
 				uc.setValidationErrors(results);
 			}
-			DataNormalizationUtils.normalize(result);
 			if (result.isValid()) {
 				Integer id = PersonContributor.getDao().add(result);
 				updateAffiliations(id, result);

--- a/src/main/java/gov/usgs/cida/pubs/busservice/sipp/SippConversionService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/sipp/SippConversionService.java
@@ -32,6 +32,7 @@ import gov.usgs.cida.pubs.domain.mp.MpPublicationLink;
 import gov.usgs.cida.pubs.domain.sipp.Author;
 import gov.usgs.cida.pubs.domain.sipp.InformationProduct;
 import gov.usgs.cida.pubs.domain.sipp.Note;
+import gov.usgs.cida.pubs.utility.DataNormalization;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 
 @Service
@@ -149,7 +150,7 @@ public class SippConversionService {
 		contributor.setFamily(familyGiven[0]);
 		contributor.setGiven(familyGiven[1]);
 
-		contributor.setOrcid(PubsUtils.normalizeOrcid(author.getOrcid()));
+		contributor.setOrcid(DataNormalization.normalizeOrcid(author.getOrcid()));
 
 		if (null != author.getNonUSGSAffiliation()) {
 			OutsideAffiliation affiliation = new OutsideAffiliation();
@@ -262,7 +263,7 @@ public class SippConversionService {
 		contributor.setFamily(familyGiven[0]);
 		contributor.setGiven(familyGiven[1]);
 
-		contributor.setOrcid(PubsUtils.normalizeOrcid(author.getOrcid()));
+		contributor.setOrcid(DataNormalization.normalizeOrcid(author.getOrcid()));
 		contributor.setPreferred(true);
 
 		if (null != author.getCostCenter()) {

--- a/src/main/java/gov/usgs/cida/pubs/busservice/sipp/SippConversionService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/sipp/SippConversionService.java
@@ -32,7 +32,7 @@ import gov.usgs.cida.pubs.domain.mp.MpPublicationLink;
 import gov.usgs.cida.pubs.domain.sipp.Author;
 import gov.usgs.cida.pubs.domain.sipp.InformationProduct;
 import gov.usgs.cida.pubs.domain.sipp.Note;
-import gov.usgs.cida.pubs.utility.DataNormalization;
+import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 
 @Service
@@ -150,7 +150,7 @@ public class SippConversionService {
 		contributor.setFamily(familyGiven[0]);
 		contributor.setGiven(familyGiven[1]);
 
-		contributor.setOrcid(DataNormalization.normalizeOrcid(author.getOrcid()));
+		contributor.setOrcid(DataNormalizationUtils.normalizeOrcid(author.getOrcid()));
 
 		if (null != author.getNonUSGSAffiliation()) {
 			OutsideAffiliation affiliation = new OutsideAffiliation();
@@ -263,7 +263,7 @@ public class SippConversionService {
 		contributor.setFamily(familyGiven[0]);
 		contributor.setGiven(familyGiven[1]);
 
-		contributor.setOrcid(DataNormalization.normalizeOrcid(author.getOrcid()));
+		contributor.setOrcid(DataNormalizationUtils.normalizeOrcid(author.getOrcid()));
 		contributor.setPreferred(true);
 
 		if (null != author.getCostCenter()) {

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -27,8 +27,8 @@ import gov.usgs.cida.pubs.validation.constraint.ParentExists;
 @Component
 @ParentExists
 public class PersonContributor<D> extends Contributor<PersonContributor<D>> implements ILookup {
-	private static final String ORCID_VALIDATION_REGEX = ".*" + DataNormalizationUtils.ORCID_REGEX;
-	private static final String ORCID_VALIDATION_MESS = "The value of orcid=${validatedValue} must include " + 
+	public static final String ORCID_VALIDATION_REGEX = ".*" + DataNormalizationUtils.ORCID_REGEX;
+	public static final String ORCID_VALIDATION_MESS = "The value of orcid=${validatedValue} must include " +
 	                             "16 digits [0-9] separated into groups of 4 by hyphens, final character optionally the letter X";
 
 	private static IPersonContributorDao personContributorDao;
@@ -105,12 +105,11 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	@JsonProperty("orcid")
 	@JsonView(View.PW.class)
 	public String getDenormalizeOrcid() {
-		String formattedOrcid = DataNormalizationUtils.denormalizeOrcid(orcid);
-		return formattedOrcid == null ? orcid : formattedOrcid;
+		return DataNormalizationUtils.denormalizeOrcid(orcid);
 	}
 
 	public void setOrcid(String orcid) {
-		this.orcid = orcid;
+		this.orcid = DataNormalizationUtils.normalizeOrcid(orcid);
 	}
 
 	public Collection<Affiliation<? extends Affiliation<?>>> getAffiliations() {

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -27,7 +27,7 @@ import gov.usgs.cida.pubs.validation.constraint.ParentExists;
 @Component
 @ParentExists
 public class PersonContributor<D> extends Contributor<PersonContributor<D>> implements ILookup {
-	public static final String ORCID_VALIDATION_REGEX = ".*" + DataNormalizationUtils.ORCID_REGEX;
+	public static final String ORCID_VALIDATION_REGEX = "^" + DataNormalizationUtils.ORCID_REGEX + "$"; // only storing short form in db
 	public static final String ORCID_VALIDATION_MESS = "The value of orcid=${validatedValue} must include " +
 	                             "16 digits [0-9] separated into groups of 4 by hyphens, final character optionally the letter X";
 

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -1,6 +1,6 @@
 package gov.usgs.cida.pubs.domain;
 
-import gov.usgs.cida.pubs.utility.DataNormalization;
+import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -27,7 +27,7 @@ import gov.usgs.cida.pubs.validation.constraint.ParentExists;
 @Component
 @ParentExists
 public class PersonContributor<D> extends Contributor<PersonContributor<D>> implements ILookup {
-	private static final String ORCID_VALIDATION_REGEX = ".*" + DataNormalization.ORCID_REGEX;
+	private static final String ORCID_VALIDATION_REGEX = ".*" + DataNormalizationUtils.ORCID_REGEX;
 	private static final String ORCID_VALIDATION_MESS = "The value of orcid=${validatedValue} must include " + 
 	                             "16 digits [0-9] separated into groups of 4 by hyphens, final character optionally the letter X";
 
@@ -105,7 +105,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	@JsonProperty("orcid")
 	@JsonView(View.PW.class)
 	public String getDenormalizeOrcid() {
-		String formattedOrcid = DataNormalization.denormalizeOrcid(orcid);
+		String formattedOrcid = DataNormalizationUtils.denormalizeOrcid(orcid);
 		return formattedOrcid == null ? orcid : formattedOrcid;
 	}
 

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -1,11 +1,14 @@
 package gov.usgs.cida.pubs.domain;
 
+import gov.usgs.cida.pubs.utility.DataNormalization;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.Length;
@@ -24,6 +27,9 @@ import gov.usgs.cida.pubs.validation.constraint.ParentExists;
 @Component
 @ParentExists
 public class PersonContributor<D> extends Contributor<PersonContributor<D>> implements ILookup {
+	private static final String ORCID_VALIDATION_REGEX = ".*" + DataNormalization.ORCID_REGEX;
+	private static final String ORCID_VALIDATION_MESS = "The value of orcid=${validatedValue} must include " + 
+	                             "16 digits [0-9] separated into groups of 4 by hyphens, final character optionally the letter X";
 
 	private static IPersonContributorDao personContributorDao;
 
@@ -49,9 +55,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	@Email
 	private String email;
 
-	@JsonProperty("orcid")
-	@JsonView(View.PW.class)
-	@Length(min=36, max=36)
+	@Pattern(regexp=ORCID_VALIDATION_REGEX, message=ORCID_VALIDATION_MESS)
 	private String orcid;
 
 	@JsonProperty("affiliations")
@@ -96,6 +100,13 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 
 	public String getOrcid() {
 		return orcid;
+	}
+
+	@JsonProperty("orcid")
+	@JsonView(View.PW.class)
+	public String getDenormalizeOrcid() {
+		String formattedOrcid = DataNormalization.denormalizeOrcid(orcid);
+		return formattedOrcid == null ? orcid : formattedOrcid;
 	}
 
 	public void setOrcid(String orcid) {

--- a/src/main/java/gov/usgs/cida/pubs/utility/DataNormalization.java
+++ b/src/main/java/gov/usgs/cida/pubs/utility/DataNormalization.java
@@ -1,0 +1,80 @@
+package gov.usgs.cida.pubs.utility;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import gov.usgs.cida.pubs.dao.PublicationDao;
+import gov.usgs.cida.pubs.domain.PersonContributor;
+
+/**
+ * Methods to transform values to and from the canonical form stored in the database
+ */
+public final class DataNormalization {
+
+	public static final String ORCID_REGEX = "\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]"; // format of the canonical short form of an orcid
+	public static final Pattern ORCID_PATTERN = Pattern.compile(ORCID_REGEX);
+	public static final String ORCID_PREFIX = "https://orcid.ord/"; // Prefix used in the long form of an orcid
+
+	/**
+	 *   returns the canonical short form (19 digits: 0000-0002-1825-0097) for the specified ORCID or null if short form not found
+	 * @param orcid The ORCDID to normalize
+	 * @return short form ORCID or null if orcid does not have a short ORCID component
+	 */
+	public static String normalizeOrcid(String orcid) {
+		String formattedOrcid = null;
+		if (null != orcid) {
+			Matcher matcher = ORCID_PATTERN.matcher(orcid);
+			if (matcher.find()) {
+				formattedOrcid = matcher.group();
+			} else {
+				formattedOrcid = null;
+			}
+		}
+		return formattedOrcid;
+	}
+
+	/**
+	 *   returns the canonical long form for the specified ORCID or null if short form not found
+	 * the protocol specified is https
+	 * @param orcid The ORCDID to denormalize
+	 * @return long form ORCID or null if orcid does not have a short ORCID component
+	 */
+	public static String denormalizeOrcid(String orcid) {
+		String formattedOrcid = null;
+		orcid = DataNormalization.normalizeOrcid(orcid);
+		if (orcid != null) {
+			formattedOrcid = ORCID_PREFIX + orcid;
+		}
+		return formattedOrcid;
+	}
+	
+	// update fields to form stored in the database
+	public static void normalize(PersonContributor<?> object) {
+		if(object != null) {
+			if(object.getOrcid() != null) {
+				String orcid = normalizeOrcid(object.getOrcid());
+				if(orcid != null) {
+					object.setOrcid(orcid);
+				}
+			}
+		}
+	}
+	
+	/** Translate filter values to format expected when querying against the database.
+	 **/
+	public static void normalizeFilters(Map<String, Object> filters) {
+		if(filters != null) {
+			String[] orcids = (String[]) filters.get(PublicationDao.ORCID);
+			if(orcids != null && orcids.length > 0) {
+				for(int i=0; i < orcids.length; i++) {
+					String orcid = normalizeOrcid(orcids[i]);
+					if(orcid != null) {
+						orcids[i] = orcid;
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/java/gov/usgs/cida/pubs/utility/DataNormalizationUtils.java
+++ b/src/main/java/gov/usgs/cida/pubs/utility/DataNormalizationUtils.java
@@ -10,7 +10,7 @@ import gov.usgs.cida.pubs.domain.PersonContributor;
 /**
  * Methods to transform values to and from the canonical form stored in the database
  */
-public final class DataNormalization {
+public final class DataNormalizationUtils {
 
 	public static final String ORCID_REGEX = "\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]"; // format of the canonical short form of an orcid
 	public static final Pattern ORCID_PATTERN = Pattern.compile(ORCID_REGEX);
@@ -42,21 +42,20 @@ public final class DataNormalization {
 	 */
 	public static String denormalizeOrcid(String orcid) {
 		String formattedOrcid = null;
-		orcid = DataNormalization.normalizeOrcid(orcid);
-		if (orcid != null) {
-			formattedOrcid = ORCID_PREFIX + orcid;
+		String normalizedOrcid = DataNormalizationUtils.normalizeOrcid(orcid);
+		if (normalizedOrcid != null) {
+			formattedOrcid = ORCID_PREFIX + normalizedOrcid;
 		}
 		return formattedOrcid;
 	}
 	
 	// update fields to form stored in the database
 	public static void normalize(PersonContributor<?> object) {
-		if(object != null) {
-			if(object.getOrcid() != null) {
-				String orcid = normalizeOrcid(object.getOrcid());
-				if(orcid != null) {
-					object.setOrcid(orcid);
-				}
+		boolean orcidIsSet = object != null && object.getOrcid() != null;
+		if(orcidIsSet) {
+			String orcid = normalizeOrcid(object.getOrcid());
+			if(orcid != null) {
+				object.setOrcid(orcid);
 			}
 		}
 	}

--- a/src/main/java/gov/usgs/cida/pubs/utility/DataNormalizationUtils.java
+++ b/src/main/java/gov/usgs/cida/pubs/utility/DataNormalizationUtils.java
@@ -1,11 +1,7 @@
 package gov.usgs.cida.pubs.utility;
 
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import gov.usgs.cida.pubs.dao.PublicationDao;
-import gov.usgs.cida.pubs.domain.PersonContributor;
 
 /**
  * Methods to transform values to and from the canonical form stored in the database
@@ -17,63 +13,47 @@ public final class DataNormalizationUtils {
 	public static final String ORCID_PREFIX = "https://orcid.ord/"; // Prefix used in the long form of an orcid
 
 	/**
-	 *   returns the canonical short form (19 digits: 0000-0002-1825-0097) for the specified ORCID or null if short form not found
+	 *   returns the canonical short form (19 digits: 0000-0002-1825-0097) for the specified ORCID or the ORCID if short form not found
 	 * @param orcid The ORCDID to normalize
-	 * @return short form ORCID or null if orcid does not have a short ORCID component
+	 * @return short form ORCID or the original orcid if orcid does not have a short ORCID component
 	 */
 	public static String normalizeOrcid(String orcid) {
-		String formattedOrcid = null;
+		String formattedOrcid = orcid;
 		if (null != orcid) {
 			Matcher matcher = ORCID_PATTERN.matcher(orcid);
 			if (matcher.find()) {
 				formattedOrcid = matcher.group();
-			} else {
-				formattedOrcid = null;
 			}
 		}
 		return formattedOrcid;
 	}
 
 	/**
-	 *   returns the canonical long form for the specified ORCID or null if short form not found
+	 *   returns the canonical long form for the specified ORCID or the ORCID unchanged if short form not found
 	 * the protocol specified is https
 	 * @param orcid The ORCDID to denormalize
-	 * @return long form ORCID or null if orcid does not have a short ORCID component
+	 * @return long form ORCID or original orcid if orcid does not have a short ORCID component
 	 */
 	public static String denormalizeOrcid(String orcid) {
-		String formattedOrcid = null;
-		String normalizedOrcid = DataNormalizationUtils.normalizeOrcid(orcid);
-		if (normalizedOrcid != null) {
-			formattedOrcid = ORCID_PREFIX + normalizedOrcid;
+		String formattedOrcid = orcid;
+		if (orcid != null && ORCID_PATTERN.matcher(orcid).find()) {
+			formattedOrcid = ORCID_PREFIX + normalizeOrcid(orcid);
 		}
 		return formattedOrcid;
 	}
-	
-	// update fields to form stored in the database
-	public static void normalize(PersonContributor<?> object) {
-		boolean orcidIsSet = object != null && object.getOrcid() != null;
-		if(orcidIsSet) {
-			String orcid = normalizeOrcid(object.getOrcid());
-			if(orcid != null) {
-				object.setOrcid(orcid);
+
+	/**
+	 * Array version of {@link #normalizeOrcid(String)}
+	 */
+	public static String[] normalizeOrcid(String[] orcids) {
+		String[] denormalizedOrcids = null;
+		if(orcids != null) {
+			denormalizedOrcids = new String[orcids.length];
+			for(int i=0; i < orcids.length; i++) {
+				denormalizedOrcids[i] =  normalizeOrcid(orcids[i]);
 			}
 		}
-	}
-	
-	/** Translate filter values to format expected when querying against the database.
-	 **/
-	public static void normalizeFilters(Map<String, Object> filters) {
-		if(filters != null) {
-			String[] orcids = (String[]) filters.get(PublicationDao.ORCID);
-			if(orcids != null && orcids.length > 0) {
-				for(int i=0; i < orcids.length; i++) {
-					String orcid = normalizeOrcid(orcids[i]);
-					if(orcid != null) {
-						orcids[i] = orcid;
-					}
-				}
-			}
-		}
+		return denormalizedOrcids;
 	}
 
 }

--- a/src/main/java/gov/usgs/cida/pubs/utility/PubsUtils.java
+++ b/src/main/java/gov/usgs/cida/pubs/utility/PubsUtils.java
@@ -5,8 +5,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -24,8 +22,6 @@ import gov.usgs.cida.pubs.domain.PublicationType;
 import gov.usgs.cida.pubs.validation.ValidatorResult;
 
 public final class PubsUtils {
-
-	public static final Pattern ORCID_PATTERN = Pattern.compile("\\d{4}-\\d{4}-\\d{4}-(\\d{3}X|\\d{4})"); //  format of the canonical short form of an orcid
 
 	private PubsUtils() {
 	}
@@ -190,24 +186,6 @@ public final class PubsUtils {
 			rtn = true;
 		}
 		return rtn;
-	}
-
-	/**
-	 *   returns the canonical short form (19 digits: 0000-0002-1825-0097) for the specified ORCID or null if short form not found
-	 * @param orcid The ORCDID to normalize
-	 * @return short form ORCID or null if orcid does not have a short ORCID component
-	 */
-	public static String normalizeOrcid(String orcid) {
-		String formattedOrcid = null;
-		if (null != orcid) {
-			Matcher matcher = ORCID_PATTERN.matcher(orcid);
-			if (matcher.find()) {
-				formattedOrcid = matcher.group();
-			} else {
-				formattedOrcid = null;
-			}
-		}
-		return formattedOrcid;
 	}
 
 }

--- a/src/main/java/gov/usgs/cida/pubs/webservice/MvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/MvcService.java
@@ -80,23 +80,6 @@ public abstract class MvcService<D> {
 		return filters;
 	}
 
-    /** Translate filter values to format expected when querying against the database.
-	 *  Only normalizing orcid to support client querying by ORCID string or https URL.
-	 **/
-	protected void normalizeFilters(Map<String, Object> filters) {
-		if(filters != null) {
-			String[] orcids = (String[]) filters.get(PublicationDao.ORCID);
-			if(orcids != null && orcids.length > 0) {
-				for(int i=0; i < orcids.length; i++) {
-					String orcid = PubsUtils.normalizeOrcid(orcids[i]);
-					if(orcid != null) {
-						orcids[i] = orcid;
-					}
-				}
-			}
-		}
-	}
-
 	protected Integer[] mapListId(String[] listId) {
 		if (null == listId) {
 			return null;

--- a/src/main/java/gov/usgs/cida/pubs/webservice/MvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/MvcService.java
@@ -22,6 +22,7 @@ import gov.usgs.cida.pubs.dao.BaseDao;
 import gov.usgs.cida.pubs.dao.PublicationDao;
 import gov.usgs.cida.pubs.dao.mp.MpPublicationDao;
 import gov.usgs.cida.pubs.dao.pw.PwPublicationDao;
+import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 
 public abstract class MvcService<D> {
@@ -45,7 +46,7 @@ public abstract class MvcService<D> {
 		filters.put(PwPublicationDao.CHORUS, chorus);
 		filters.put(PublicationDao.CONTRIBUTING_OFFICE, contributingOffice);
 		filters.put(PublicationDao.CONTRIBUTOR, configureContributorFilter(contributor));
-		filters.put(PublicationDao.ORCID, orcid);
+		filters.put(PublicationDao.ORCID, DataNormalizationUtils.normalizeOrcid(orcid));
 		filters.put(PublicationDao.DOI, doi);
 		filters.put(PublicationDao.END_YEAR, endYear);
 		if (null != g && G_PATTERN.matcher(g.toLowerCase()).matches()) {

--- a/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
@@ -46,6 +46,7 @@ import gov.usgs.cida.pubs.transform.JsonTransformer;
 import gov.usgs.cida.pubs.transform.PublicationColumnsHelper;
 import gov.usgs.cida.pubs.transform.XlsxTransformer;
 import gov.usgs.cida.pubs.transform.intfc.ITransformer;
+import gov.usgs.cida.pubs.utility.DataNormalization;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 import gov.usgs.cida.pubs.webservice.MvcService;
 import io.swagger.annotations.ApiParam;
@@ -136,7 +137,7 @@ public class PwPublicationMvcService extends MvcService<PwPublication> {
 		response.setCharacterEncoding(PubsConstantsHelper.DEFAULT_ENCODING);
 		String statement = PwPublicationDao.NS;
 
-        normalizeFilters(filters);
+        DataNormalization.normalizeFilters(filters);
 
 		try {
 			ITransformer transformer;

--- a/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
@@ -46,7 +46,7 @@ import gov.usgs.cida.pubs.transform.JsonTransformer;
 import gov.usgs.cida.pubs.transform.PublicationColumnsHelper;
 import gov.usgs.cida.pubs.transform.XlsxTransformer;
 import gov.usgs.cida.pubs.transform.intfc.ITransformer;
-import gov.usgs.cida.pubs.utility.DataNormalization;
+import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 import gov.usgs.cida.pubs.webservice.MvcService;
 import io.swagger.annotations.ApiParam;
@@ -137,7 +137,7 @@ public class PwPublicationMvcService extends MvcService<PwPublication> {
 		response.setCharacterEncoding(PubsConstantsHelper.DEFAULT_ENCODING);
 		String statement = PwPublicationDao.NS;
 
-        DataNormalization.normalizeFilters(filters);
+        DataNormalizationUtils.normalizeFilters(filters);
 
 		try {
 			ITransformer transformer;

--- a/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
@@ -137,8 +137,6 @@ public class PwPublicationMvcService extends MvcService<PwPublication> {
 		response.setCharacterEncoding(PubsConstantsHelper.DEFAULT_ENCODING);
 		String statement = PwPublicationDao.NS;
 
-        DataNormalizationUtils.normalizeFilters(filters);
-
 		try {
 			ITransformer transformer;
 			SearchResults searchResults = null;

--- a/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/pw/PwPublicationMvcService.java
@@ -46,7 +46,6 @@ import gov.usgs.cida.pubs.transform.JsonTransformer;
 import gov.usgs.cida.pubs.transform.PublicationColumnsHelper;
 import gov.usgs.cida.pubs.transform.XlsxTransformer;
 import gov.usgs.cida.pubs.transform.intfc.ITransformer;
-import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 import gov.usgs.cida.pubs.webservice.MvcService;
 import io.swagger.annotations.ApiParam;

--- a/src/test/java/gov/usgs/cida/pubs/busservice/PersonContributorBusServiceIT.java
+++ b/src/test/java/gov/usgs/cida/pubs/busservice/PersonContributorBusServiceIT.java
@@ -2,6 +2,7 @@ package gov.usgs.cida.pubs.busservice;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import javax.validation.Validator;
 
@@ -91,11 +92,20 @@ public class PersonContributorBusServiceIT extends BaseIT {
 
 		assertTrue("Expected id not to be set: " + person.getId(), person.getId() == null || person.getId() == 0);
 
-		boolean hasValidationMess = person.getValidationErrors() != null && !person.getValidationErrors().isEmpty();
-		assertTrue("Expected a validation error message", hasValidationMess);
+		boolean hasValidationMess = false;
+		String expectedMess = PersonContributor.ORCID_VALIDATION_MESS.replace("${validatedValue}", person.getOrcid());
+		String validationMessage = "[no validation message found]";
 
-		boolean isValidIsFalse = !person.isValid();
-		assertTrue("Expected isValid() to be false", isValidIsFalse);
+		if(person.getValidationErrors() != null && !person.getValidationErrors().isEmpty()) {
+			validationMessage = person.getValidationErrors().toString();
+			if(validationMessage.contains(expectedMess)) {
+				hasValidationMess = true;
+			}
+		}
+		String testMess = "Expected validation error message: " + expectedMess + " got: " + validationMessage;
+		assertTrue(testMess, hasValidationMess);
+
+		assertFalse("Expected isValid() to be false", person.isValid());
 	}
 
 }

--- a/src/test/java/gov/usgs/cida/pubs/busservice/PersonContributorBusServiceIT.java
+++ b/src/test/java/gov/usgs/cida/pubs/busservice/PersonContributorBusServiceIT.java
@@ -1,6 +1,7 @@
 package gov.usgs.cida.pubs.busservice;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import javax.validation.Validator;
 
@@ -58,6 +59,7 @@ public class PersonContributorBusServiceIT extends BaseIT {
 		person.setOrcid("http://orcid.org/0000-0002-1825-0097");
 		person.setPreferred(true);
 		busService.createObject(person);
+		assertTrue("Expected isValid() true, got validation errors: " + person.getValidationErrors(), person.isValid());
 		assertNotNull(person.getId());
 		UsgsContributor persisted = (UsgsContributor) Contributor.getDao().getById(person.getId());
 		assertDaoTestResults(UsgsContributor.class, person, persisted, ContributorDaoIT.IGNORE_PROPERTIES_PERSON, true, true);
@@ -68,11 +70,32 @@ public class PersonContributorBusServiceIT extends BaseIT {
 		outperson.setGiven("outgiven");
 		outperson.setSuffix("outsuffix");
 		outperson.setEmail("outemail@usgs.gov");
-		outperson.setOrcid("http://orcid.org/0000-0002-1825-0097");
+		outperson.setOrcid("0000-0002-1825-0097"); // service stores normalized orcid
 		outperson.setPreferred(true);
 		busService.createObject(outperson);
 		assertNotNull(outperson.getId());
 		OutsideContributor outpersisted = (OutsideContributor) Contributor.getDao().getById(outperson.getId());
 		assertDaoTestResults(OutsideContributor.class, outperson, outpersisted, ContributorDaoIT.IGNORE_PROPERTIES_PERSON, true, true);
 	}
+
+	@Test
+	public void orcidValidationTest() {
+		UsgsContributor person = new UsgsContributor();
+		person.setFamily("family");
+		person.setGiven("given");
+		person.setSuffix("suffix");
+		person.setEmail("email@usgs.gov");
+		person.setOrcid("http://orcid.org/0000-0002-1825-009R");
+		person.setPreferred(true);
+		busService.createObject(person);
+
+		assertTrue("Expected id not to be set: " + person.getId(), person.getId() == null || person.getId() == 0);
+
+		boolean hasValidationMess = person.getValidationErrors() != null && !person.getValidationErrors().isEmpty();
+		assertTrue("Expected a validation error message", hasValidationMess);
+
+		boolean isValidIsFalse = !person.isValid();
+		assertTrue("Expected isValid() to be false", isValidIsFalse);
+	}
+
 }

--- a/src/test/java/gov/usgs/cida/pubs/utility/DataNormalizationTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/utility/DataNormalizationTest.java
@@ -35,44 +35,44 @@ public class DataNormalizationTest extends BaseTest {
 	@Test
     public void testNormalizeOrcid() {
 
-            assertNull(DataNormalization.normalizeOrcid(orcidNull));
-            assertNull(DataNormalization.normalizeOrcid(orcidPrefixNoNumber));
-            assertNull(DataNormalization.normalizeOrcid(orcidBadNumber));
-            assertNull(DataNormalization.normalizeOrcid(orcidPrefixBadNumber));
-            assertNull(DataNormalization.normalizeOrcid(orcidBadPrefixNoNumber));
-            assertNull(DataNormalization.normalizeOrcid(orcidBadPrefixBadNumber));
+            assertNull(DataNormalizationUtils.normalizeOrcid(orcidNull));
+            assertNull(DataNormalizationUtils.normalizeOrcid(orcidPrefixNoNumber));
+            assertNull(DataNormalizationUtils.normalizeOrcid(orcidBadNumber));
+            assertNull(DataNormalizationUtils.normalizeOrcid(orcidPrefixBadNumber));
+            assertNull(DataNormalizationUtils.normalizeOrcid(orcidBadPrefixNoNumber));
+            assertNull(DataNormalizationUtils.normalizeOrcid(orcidBadPrefixBadNumber));
 
-            assertEquals(orcidGoodNumber, DataNormalization.normalizeOrcid(orcidGoodNumber));
-            assertEquals(orcidGoodNumber, DataNormalization.normalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
-            assertEquals("0000-0000-0000-0000", DataNormalization.normalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
-            assertEquals("0000-0000-0000-000X", DataNormalization.normalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
+            assertEquals(orcidGoodNumber, DataNormalizationUtils.normalizeOrcid(orcidGoodNumber));
+            assertEquals(orcidGoodNumber, DataNormalizationUtils.normalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
+            assertEquals("0000-0000-0000-0000", DataNormalizationUtils.normalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
+            assertEquals("0000-0000-0000-000X", DataNormalizationUtils.normalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
 
-            assertEquals("0000-0000-0000-0000", DataNormalization.normalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
-            assertEquals("0000-0000-0000-000X", DataNormalization.normalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
+            assertEquals("0000-0000-0000-0000", DataNormalizationUtils.normalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
+            assertEquals("0000-0000-0000-000X", DataNormalizationUtils.normalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
     }
 
 	@Test
     public void testDeormalizeOrcid() {
-            assertNull(DataNormalization.denormalizeOrcid(orcidNull));
-            assertNull(DataNormalization.denormalizeOrcid(orcidPrefixNoNumber));
-            assertNull(DataNormalization.denormalizeOrcid(orcidBadNumber));
-            assertNull(DataNormalization.denormalizeOrcid(orcidPrefixBadNumber));
-            assertNull(DataNormalization.denormalizeOrcid(orcidBadPrefixNoNumber));
-            assertNull(DataNormalization.denormalizeOrcid(orcidBadPrefixBadNumber));
+            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidNull));
+            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidPrefixNoNumber));
+            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidBadNumber));
+            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidPrefixBadNumber));
+            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidBadPrefixNoNumber));
+            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidBadPrefixBadNumber));
 
-            String orcidPrefix = DataNormalization.ORCID_PREFIX;
+            String orcidPrefix = DataNormalizationUtils.ORCID_PREFIX;
 
-            assertEquals(orcidPrefix + orcidGoodNumber, DataNormalization.denormalizeOrcid(orcidGoodNumber));
-            assertEquals(orcidPrefix + orcidGoodNumber, DataNormalization.denormalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
+            assertEquals(orcidPrefix + orcidGoodNumber, DataNormalizationUtils.denormalizeOrcid(orcidGoodNumber));
+            assertEquals(orcidPrefix + orcidGoodNumber, DataNormalizationUtils.denormalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
 
-            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalization.denormalizeOrcid("0000-0000-0000-0000"));
-            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalization.denormalizeOrcid("0000-0000-0000-000X"));
+            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalizationUtils.denormalizeOrcid("0000-0000-0000-0000"));
+            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalizationUtils.denormalizeOrcid("0000-0000-0000-000X"));
 
-            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalization.denormalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
-            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalization.denormalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
+            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalizationUtils.denormalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
+            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalizationUtils.denormalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
 
-            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalization.denormalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
-            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalization.denormalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
+            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalizationUtils.denormalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
+            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalizationUtils.denormalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
 	}
 
 }

--- a/src/test/java/gov/usgs/cida/pubs/utility/DataNormalizationTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/utility/DataNormalizationTest.java
@@ -1,0 +1,78 @@
+package gov.usgs.cida.pubs.utility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
+import static org.mockito.Mockito.when;
+import gov.usgs.cida.pubs.BaseTest;
+import gov.usgs.cida.pubs.ConfigurationService;
+import gov.usgs.cida.pubs.TestOAuth;
+
+@SecurityTestExecutionListeners
+public class DataNormalizationTest extends BaseTest {
+    private static final String orcidNull = null;
+    private static final String orcidPrefixNoNumber = "http://orcid/";
+    private static final String orcidGoodNumber = "0000-0002-1824-0097";
+    private static final String orcidBadNumber = "ojae-hjrg-aag2-0020";
+    private static final String orcidPrefixBadNumber = orcidPrefixNoNumber + orcidBadNumber;
+    private static final String orcidBadPrefixNoNumber = "http://notorcid.org";
+    private static final String orcidBadPrefixBadNumber = "http://gro.dicro" + "1234-5678-9101-112K";
+
+	@Mock
+	ConfigurationService configurationService;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		when(configurationService.getAuthorizedAuthorities()).thenReturn(new String[] {TestOAuth.AUTHORIZED_AUTHORITY, TestOAuth.SPN_AUTHORITY, "silly", "willy"});
+		when(configurationService.getSpnAuthorities()).thenReturn(new String[] {TestOAuth.SPN_AUTHORITY, "silly"});
+	}
+
+	@Test
+    public void testNormalizeOrcid() {
+
+            assertNull(DataNormalization.normalizeOrcid(orcidNull));
+            assertNull(DataNormalization.normalizeOrcid(orcidPrefixNoNumber));
+            assertNull(DataNormalization.normalizeOrcid(orcidBadNumber));
+            assertNull(DataNormalization.normalizeOrcid(orcidPrefixBadNumber));
+            assertNull(DataNormalization.normalizeOrcid(orcidBadPrefixNoNumber));
+            assertNull(DataNormalization.normalizeOrcid(orcidBadPrefixBadNumber));
+
+            assertEquals(orcidGoodNumber, DataNormalization.normalizeOrcid(orcidGoodNumber));
+            assertEquals(orcidGoodNumber, DataNormalization.normalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
+            assertEquals("0000-0000-0000-0000", DataNormalization.normalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
+            assertEquals("0000-0000-0000-000X", DataNormalization.normalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
+
+            assertEquals("0000-0000-0000-0000", DataNormalization.normalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
+            assertEquals("0000-0000-0000-000X", DataNormalization.normalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
+    }
+
+	@Test
+    public void testDeormalizeOrcid() {
+            assertNull(DataNormalization.denormalizeOrcid(orcidNull));
+            assertNull(DataNormalization.denormalizeOrcid(orcidPrefixNoNumber));
+            assertNull(DataNormalization.denormalizeOrcid(orcidBadNumber));
+            assertNull(DataNormalization.denormalizeOrcid(orcidPrefixBadNumber));
+            assertNull(DataNormalization.denormalizeOrcid(orcidBadPrefixNoNumber));
+            assertNull(DataNormalization.denormalizeOrcid(orcidBadPrefixBadNumber));
+
+            String orcidPrefix = DataNormalization.ORCID_PREFIX;
+
+            assertEquals(orcidPrefix + orcidGoodNumber, DataNormalization.denormalizeOrcid(orcidGoodNumber));
+            assertEquals(orcidPrefix + orcidGoodNumber, DataNormalization.denormalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
+
+            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalization.denormalizeOrcid("0000-0000-0000-0000"));
+            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalization.denormalizeOrcid("0000-0000-0000-000X"));
+
+            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalization.denormalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
+            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalization.denormalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
+
+            assertEquals(orcidPrefix + "0000-0000-0000-0000", DataNormalization.denormalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
+            assertEquals(orcidPrefix + "0000-0000-0000-000X", DataNormalization.denormalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
+	}
+
+}

--- a/src/test/java/gov/usgs/cida/pubs/utility/DataNormalizationTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/utility/DataNormalizationTest.java
@@ -36,11 +36,11 @@ public class DataNormalizationTest extends BaseTest {
     public void testNormalizeOrcid() {
 
             assertNull(DataNormalizationUtils.normalizeOrcid(orcidNull));
-            assertNull(DataNormalizationUtils.normalizeOrcid(orcidPrefixNoNumber));
-            assertNull(DataNormalizationUtils.normalizeOrcid(orcidBadNumber));
-            assertNull(DataNormalizationUtils.normalizeOrcid(orcidPrefixBadNumber));
-            assertNull(DataNormalizationUtils.normalizeOrcid(orcidBadPrefixNoNumber));
-            assertNull(DataNormalizationUtils.normalizeOrcid(orcidBadPrefixBadNumber));
+            assertEquals(orcidPrefixNoNumber,DataNormalizationUtils.normalizeOrcid(orcidPrefixNoNumber));
+            assertEquals(orcidBadNumber, DataNormalizationUtils.normalizeOrcid(orcidBadNumber));
+            assertEquals(orcidPrefixBadNumber, DataNormalizationUtils.normalizeOrcid(orcidPrefixBadNumber));
+            assertEquals(orcidBadPrefixNoNumber, DataNormalizationUtils.normalizeOrcid(orcidBadPrefixNoNumber));
+            assertEquals(orcidBadPrefixBadNumber, DataNormalizationUtils.normalizeOrcid(orcidBadPrefixBadNumber));
 
             assertEquals(orcidGoodNumber, DataNormalizationUtils.normalizeOrcid(orcidGoodNumber));
             assertEquals(orcidGoodNumber, DataNormalizationUtils.normalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
@@ -54,11 +54,11 @@ public class DataNormalizationTest extends BaseTest {
 	@Test
     public void testDeormalizeOrcid() {
             assertNull(DataNormalizationUtils.denormalizeOrcid(orcidNull));
-            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidPrefixNoNumber));
-            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidBadNumber));
-            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidPrefixBadNumber));
-            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidBadPrefixNoNumber));
-            assertNull(DataNormalizationUtils.denormalizeOrcid(orcidBadPrefixBadNumber));
+            assertEquals(orcidPrefixNoNumber,DataNormalizationUtils.denormalizeOrcid(orcidPrefixNoNumber));
+            assertEquals(orcidBadNumber, DataNormalizationUtils.denormalizeOrcid(orcidBadNumber));
+            assertEquals(orcidPrefixBadNumber, DataNormalizationUtils.denormalizeOrcid(orcidPrefixBadNumber));
+            assertEquals(orcidBadPrefixNoNumber, DataNormalizationUtils.denormalizeOrcid(orcidBadPrefixNoNumber));
+            assertEquals(orcidBadPrefixBadNumber, DataNormalizationUtils.denormalizeOrcid(orcidBadPrefixBadNumber));
 
             String orcidPrefix = DataNormalizationUtils.ORCID_PREFIX;
 

--- a/src/test/java/gov/usgs/cida/pubs/utility/PubsUtilitiesTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/utility/PubsUtilitiesTest.java
@@ -156,32 +156,6 @@ public class PubsUtilitiesTest extends BaseTest {
 	}
 
 	@Test
-    public void testNormalizeOrcid() {
-            String orcidNull = null;
-            String orcidPrefixNoNumber = "http://orcid/";
-            String orcidGoodNumber = "0000-0002-1824-0097";
-            String orcidBadNumber = "ojae-hjrg-aag2-0020";
-            String orcidPrefixBadNumber = orcidPrefixNoNumber + orcidBadNumber;
-            String orcidBadPrefixNoNumber = "http://notorcid.org";
-            String orcidBadPrefixBadNumber = "http://gro.dicro" + "1234-5678-9101-112K";
-
-            assertNull(PubsUtils.normalizeOrcid(orcidNull));
-            assertNull(PubsUtils.normalizeOrcid(orcidPrefixNoNumber));
-            assertNull(PubsUtils.normalizeOrcid(orcidBadNumber));
-            assertNull(PubsUtils.normalizeOrcid(orcidPrefixBadNumber));
-            assertNull(PubsUtils.normalizeOrcid(orcidBadPrefixNoNumber));
-            assertNull(PubsUtils.normalizeOrcid(orcidBadPrefixBadNumber));
-
-            assertEquals(orcidGoodNumber, PubsUtils.normalizeOrcid(orcidGoodNumber));
-            assertEquals(orcidGoodNumber, PubsUtils.normalizeOrcid(orcidPrefixNoNumber + orcidGoodNumber));
-            assertEquals("0000-0000-0000-0000", PubsUtils.normalizeOrcid("http://orcid.org/0000-0000-0000-0000"));
-            assertEquals("0000-0000-0000-000X", PubsUtils.normalizeOrcid("http://orcid.org/0000-0000-0000-000X"));
-
-            assertEquals("0000-0000-0000-0000", PubsUtils.normalizeOrcid("https://orcid.org/0000-0000-0000-0000"));
-            assertEquals("0000-0000-0000-000X", PubsUtils.normalizeOrcid("https://orcid.org/0000-0000-0000-000X"));
-    }
-
-	@Test
 	public void isSpnUserTest_noAuthentication() {
 		assertFalse(PubsUtils.isSpnUser(configurationService));
 	}

--- a/src/test/java/gov/usgs/cida/pubs/webservice/MvcServiceTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/webservice/MvcServiceTest.java
@@ -28,6 +28,7 @@ import gov.usgs.cida.pubs.dao.PersonContributorDao;
 import gov.usgs.cida.pubs.dao.PublicationDao;
 import gov.usgs.cida.pubs.dao.mp.MpPublicationDao;
 import gov.usgs.cida.pubs.dao.pw.PwPublicationDao;
+import gov.usgs.cida.pubs.utility.DataNormalizationUtils;
 
 public class MvcServiceTest {
 
@@ -91,7 +92,7 @@ public class MvcServiceTest {
 		assertTrue(filters.containsKey(PublicationDao.CONTRIBUTOR));
 		assertEquals("rebecca:* & b.:* & carvin:* & c2:*", filters.get(PublicationDao.CONTRIBUTOR));
 		assertTrue(filters.containsKey(PersonContributorDao.ORCID));
-		assertEquals(orcid, filters.get(PersonContributorDao.ORCID));
+		assertTrue(Arrays.equals(DataNormalizationUtils.normalizeOrcid(orcid), (String[]) filters.get(PersonContributorDao.ORCID)));
 		assertEquals(doi, filters.get(PublicationDao.DOI));
 		assertTrue(filters.containsKey(PublicationDao.END_YEAR));
 		assertEquals(endYear, filters.get(PublicationDao.END_YEAR));


### PR DESCRIPTION
Moved data normalization routines from PubsUtils to DataNormalaztion utility class
Added DataNormalization.denoramlizeOrcid, recfactored code to have regex seperate from Pattern
Updated PersonContributor to have in the json, the orcid field displayed the long form with https
Validated PersonContributor orcid field with @Pattern
Updated PersonContributorBusService to normalize orcid on create or update
Fixed IT tests to use short form orcid