### PR TITLE
PUBSTWO-1703 (Change lookups that use active parameter to use active=…

### DIFF
--- a/src/main/java/gov/usgs/cida/pubs/domain/CostCenter.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/CostCenter.java
@@ -3,8 +3,6 @@ package gov.usgs.cida.pubs.domain;
 import gov.usgs.cida.pubs.dao.intfc.IDao;
 import gov.usgs.cida.pubs.utility.PubsUtils;
 
-import java.io.Serializable;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -12,9 +10,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Component
-public class CostCenter extends Affiliation<CostCenter> implements Serializable {
-
-	private static final long serialVersionUID = -7804226743028056085L;
+public class CostCenter extends Affiliation<CostCenter> {
 
 	private static IDao<CostCenter> costCenterDao;
 

--- a/src/main/java/gov/usgs/cida/pubs/webservice/LookupMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/LookupMvcService.java
@@ -115,7 +115,7 @@ public class LookupMvcService extends MvcService<PublicationType> {
 			@PathVariable("publicationTypeId") Integer publicationTypeId,
 			@PathVariable("publicationSubtypeId") Integer publicationSubtypeId,
 			@RequestParam(value=TEXT_SEARCH, required=false) String[] text,
-			@RequestParam(value=ACTIVE_SEARCH, required=false) String[] active) {
+			@RequestParam(value=ACTIVE_SEARCH, required=false) Boolean active) {
 		LOG.debug("publicationSeries");
 		Collection<PublicationSeries> rtn = new ArrayList<>();
 		if (validateParametersSetHeaders(request, response)) {
@@ -124,8 +124,8 @@ public class LookupMvcService extends MvcService<PublicationType> {
 			if (null != text && 0 < text.length) {
 				filters.put(PublicationSeriesDao.TEXT_SEARCH, text[0]);
 			}
-			if (null != active && 0 < active.length) {
-				filters.put(PublicationSeriesDao.ACTIVE_SEARCH, active[0].toUpperCase());
+			if (null != active) {
+				filters.put(PublicationSeriesDao.ACTIVE_SEARCH, active);
 			}
 			rtn = PublicationSeries.getDao().getByMap(filters);
 		}
@@ -137,7 +137,7 @@ public class LookupMvcService extends MvcService<PublicationType> {
 	public @ResponseBody Collection<PublicationSeries> getPublicationSeriesQuery(HttpServletRequest request, HttpServletResponse response,
 				@RequestParam(value=TEXT_SEARCH, required=false) String[] text,
 				@RequestParam(value="publicationsubtypeid", required=false) Integer[] publicationSubtypeId,
-				@RequestParam(value=ACTIVE_SEARCH, required=false) String[] active) {
+				@RequestParam(value=ACTIVE_SEARCH, required=false) Boolean active) {
 		LOG.debug("publicationSeries");
 		Collection<PublicationSeries> rtn = new ArrayList<>();
 		if (validateParametersSetHeaders(request, response)) {
@@ -148,8 +148,8 @@ public class LookupMvcService extends MvcService<PublicationType> {
 			if (null != text && 0 < text.length) {
 				filters.put(PublicationSeriesDao.TEXT_SEARCH, text[0]);
 			}
-			if (null != active && 0 < active.length) {
-				filters.put(PublicationSeriesDao.ACTIVE_SEARCH, active[0].toUpperCase());
+			if (null != active) {
+				filters.put(PublicationSeriesDao.ACTIVE_SEARCH, active);
 			}
 			rtn = PublicationSeries.getDao().getByMap(filters);
 		}
@@ -160,7 +160,7 @@ public class LookupMvcService extends MvcService<PublicationType> {
 	@JsonView(View.Lookup.class)
 	public @ResponseBody Collection<CostCenter> getCostCentersLookup(HttpServletRequest request, HttpServletResponse response,
 				@RequestParam(value=TEXT_SEARCH, required=false) String[] text,
-				@RequestParam(value=ACTIVE_SEARCH, required=false) String[] active) {
+				@RequestParam(value=ACTIVE_SEARCH, required=false) Boolean active) {
 		LOG.debug("CostCenter");
 		Collection<CostCenter> rtn = new ArrayList<>();
 		if (validateParametersSetHeaders(request, response)) {
@@ -168,8 +168,8 @@ public class LookupMvcService extends MvcService<PublicationType> {
 			if (null != text && 0 < text.length) {
 				filters.put(CostCenterDao.TEXT_SEARCH, text[0]);
 			}
-			if (null != active && 0 < active.length) {
-				filters.put(CostCenterDao.ACTIVE_SEARCH, active[0].toUpperCase());
+			if (null != active) {
+				filters.put(CostCenterDao.ACTIVE_SEARCH, active);
 			}
 			rtn = CostCenter.getDao().getByMap(filters);
 		}
@@ -180,7 +180,7 @@ public class LookupMvcService extends MvcService<PublicationType> {
 	@JsonView(View.Lookup.class)
 	public @ResponseBody Collection<OutsideAffiliation> getOutsideAffiliates(HttpServletRequest request, HttpServletResponse response,
 				@RequestParam(value=TEXT_SEARCH, required=false) String[] text,
-				@RequestParam(value=ACTIVE_SEARCH, required=false) String[] active) {
+				@RequestParam(value=ACTIVE_SEARCH, required=false) Boolean active) {
 		LOG.debug("OutsideAffiliate");
 		Collection<OutsideAffiliation> rtn = new ArrayList<>();
 		if (validateParametersSetHeaders(request, response)) {
@@ -188,8 +188,8 @@ public class LookupMvcService extends MvcService<PublicationType> {
 			if (null != text && 0 < text.length) {
 				filters.put(OutsideAffiliationDao.TEXT_SEARCH, text[0]);
 			}
-			if (null != active && 0 < active.length) {
-				filters.put(OutsideAffiliationDao.ACTIVE_SEARCH, active[0].toUpperCase());
+			if (null != active) {
+				filters.put(OutsideAffiliationDao.ACTIVE_SEARCH, active);
 			}
 			rtn = OutsideAffiliation.getDao().getByMap(filters);
 		}

--- a/src/test/java/gov/usgs/cida/pubs/webservice/LookupMvcServiceBuildDbIT.java
+++ b/src/test/java/gov/usgs/cida/pubs/webservice/LookupMvcServiceBuildDbIT.java
@@ -179,10 +179,10 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 		assertThat(getRtnAsJSONArray(rtn),
 				sameJSONArrayAs(new JSONArray("[{\"id\":6,\"text\":\"xOutside Affiliation 2\"}]")));
 
-		rtn = performGetRequest(endPoint + "?active=false");
+		rtn = performGetRequest(endPoint + "&active=false");
 		assertEquals(1, getRtnAsJSONArray(rtn).length());
 
-		rtn = performGetRequest(endPoint + "?active=true");
+		rtn = performGetRequest(endPoint + "&active=true");
 		assertEquals(2, getRtnAsJSONArray(rtn).length());
 	}
 

--- a/src/test/java/gov/usgs/cida/pubs/webservice/LookupMvcServiceBuildDbIT.java
+++ b/src/test/java/gov/usgs/cida/pubs/webservice/LookupMvcServiceBuildDbIT.java
@@ -134,7 +134,8 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 
 	@Test
 	public void getCostCenters() throws Exception {
-		MvcResult rtn = mockMvc.perform(get("/lookup/costcenters?mimetype=json").accept(MediaType.APPLICATION_JSON))
+		String endPoint = "/lookup/costcenters";
+		MvcResult rtn = mockMvc.perform(get(endPoint + "?mimetype=json").accept(MediaType.APPLICATION_JSON))
 		.andExpect(status().isOk())
 		.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
 		.andExpect(content().encoding(PubsConstantsHelper.DEFAULT_ENCODING))
@@ -142,7 +143,7 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 
 		assertEquals(CostCenterDaoIT.COST_CENTER_CNT, getRtnAsJSONArray(rtn).length());
 
-		rtn = mockMvc.perform(get("/lookup/costcenters?text=xa").accept(MediaType.APPLICATION_JSON))
+		rtn = mockMvc.perform(get(endPoint + "?text=xa").accept(MediaType.APPLICATION_JSON))
 		.andExpect(status().isOk())
 		.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
 		.andExpect(content().encoding(PubsConstantsHelper.DEFAULT_ENCODING))
@@ -150,11 +151,18 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 
 		assertThat(getRtnAsJSONArray(rtn),
 				sameJSONArrayAs(new JSONArray("[{\"id\":3,\"text\":\"xAffiliation Cost Center 3\"},{\"id\":4,\"text\":\"xAffiliation Cost Center 4\"}]")));
+
+		rtn = performGetRequest(endPoint + "?active=false");
+		assertEquals(1, getRtnAsJSONArray(rtn).length());
+
+		rtn = performGetRequest(endPoint + "?active=true");
+		assertEquals(4, getRtnAsJSONArray(rtn).length());
 	}
 
 	@Test
 	public void getOutsideAffiliates() throws Exception {
-		MvcResult rtn = mockMvc.perform(get("/lookup/outsideaffiliates?mimetype=json").accept(MediaType.APPLICATION_JSON))
+		String endPoint = "/lookup/outsideaffiliates?mimetype=json";
+		MvcResult rtn = mockMvc.perform(get(endPoint).accept(MediaType.APPLICATION_JSON))
 		.andExpect(status().isOk())
 		.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
 		.andExpect(content().encoding(PubsConstantsHelper.DEFAULT_ENCODING))
@@ -170,6 +178,12 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 
 		assertThat(getRtnAsJSONArray(rtn),
 				sameJSONArrayAs(new JSONArray("[{\"id\":6,\"text\":\"xOutside Affiliation 2\"}]")));
+
+		rtn = performGetRequest(endPoint + "?active=false");
+		assertEquals(1, getRtnAsJSONArray(rtn).length());
+
+		rtn = performGetRequest(endPoint + "?active=true");
+		assertEquals(2, getRtnAsJSONArray(rtn).length());
 	}
 
 	@Test
@@ -206,6 +220,16 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 				sameJSONArrayAs(new JSONArray("[{\"id\":3803,\"text\":\"Zeitschrift fur Geomorphologie\"},"
 						+ "{\"id\":3804,\"text\":\"Zeitschrift fur Geomorphologie, Supplementband\"},"
 						+ "{\"id\":3805,\"text\":\"Zeitschrift fur Tierpsychologie\"}]")));
+
+		String endPoint = "/lookup/publicationseries";
+		rtn = performGetRequest(endPoint);
+		assertEquals(16, getRtnAsJSONArray(rtn).length());
+
+		rtn = performGetRequest(endPoint + "?active=false");
+		assertEquals(7, getRtnAsJSONArray(rtn).length());
+
+		rtn = performGetRequest(endPoint + "?active=true");
+		assertEquals(9, getRtnAsJSONArray(rtn).length());
 	}
 
 	@Test
@@ -221,6 +245,16 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 				sameJSONArrayAs(new JSONArray("[{\"id\":3803,\"text\":\"Zeitschrift fur Geomorphologie\"},"
 						+ "{\"id\":3804,\"text\":\"Zeitschrift fur Geomorphologie, Supplementband\"},"
 						+ "{\"id\":3805,\"text\":\"Zeitschrift fur Tierpsychologie\"}]")));
+
+		String endPoint = "/lookup/publicationtype/5/publicationsubtype/5/publicationseries";
+		rtn = performGetRequest(endPoint);
+		assertEquals(9, getRtnAsJSONArray(rtn).length());
+
+		rtn = performGetRequest(endPoint + "?active=false");
+		assertEquals(4, getRtnAsJSONArray(rtn).length());
+
+		rtn = performGetRequest(endPoint + "?active=true");
+		assertEquals(5, getRtnAsJSONArray(rtn).length());
 	}
 
 	@Test
@@ -245,6 +279,7 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 
 		assertThat(getRtnAsJSONArray(rtn),
 				sameJSONArrayAs(new JSONArray("[{\"id\":11,\"text\":\"Bibliography\"}]")).allowingAnyArrayOrdering());
+
 	}
 
 	@Test
@@ -284,6 +319,13 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 				sameJSONArrayAs(new JSONArray(
 						"[{\"id\":4,\"text\":\"Rolla PSC\"},{\"id\":8,\"text\":\"Raleigh PSC\"},{\"id\":9,\"text\":\"Reston PSC\"}]"))
 								.allowingAnyArrayOrdering());
+	}
+
+	private MvcResult performGetRequest(String path) throws Exception {
+		MvcResult rtn = mockMvc.perform(get(path).accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+				.andExpect(content().encoding(PubsConstantsHelper.DEFAULT_ENCODING)).andReturn();
+		return rtn;
 	}
 
 	private JSONArray contributor3JsonArray() throws JSONException {


### PR DESCRIPTION
…true/false.)

   In LookupMvcService.java, changed query parameter active to be of type Boolean.
   Updated test to call endpoints with active query parameter set to true and and
active set to false.
  cleanup Serializable from CostCenter