### PR TITLE
PUBSTWO-1701 (Don't ever link to index pages in crossref submission, …

### DIFF
--- a/src/main/java/gov/usgs/cida/pubs/busservice/PublicationBusService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/PublicationBusService.java
@@ -1,7 +1,5 @@
 package gov.usgs.cida.pubs.busservice;
 
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -10,9 +8,7 @@ import org.springframework.stereotype.Service;
 
 import gov.usgs.cida.pubs.ConfigurationService;
 import gov.usgs.cida.pubs.busservice.intfc.IPublicationBusService;
-import gov.usgs.cida.pubs.domain.LinkType;
 import gov.usgs.cida.pubs.domain.Publication;
-import gov.usgs.cida.pubs.domain.PublicationLink;
 
 @Service
 public class PublicationBusService extends BusService<Publication<?>> implements IPublicationBusService {
@@ -34,23 +30,12 @@ public class PublicationBusService extends BusService<Publication<?>> implements
 	}
 
 	@Override
-	public String getIndexPage(Publication<?> pub) {
+	public String getWarehousePage(Publication<?> pub) {
 		String rtn = "";
-		if (null != pub) {
-			if (null != pub.getLinks()) {
-				Collection<PublicationLink<?>> links = pub.getLinks();
-				for (Iterator<PublicationLink<?>> linksIter = links.iterator(); linksIter.hasNext();) {
-					PublicationLink<?> link = linksIter.next();
-					if (null != link.getLinkType() && LinkType.INDEX_PAGE.equals(link.getLinkType().getId())) {
-						rtn = link.getUrl();
-					}
-				}
-			}
-			if (rtn.isEmpty() && null != pub.getIndexId()) {
-				rtn = configurationService.getWarehouseEndpoint() + "/publication/" + pub.getIndexId();
-			}
+		if(pub != null && pub.getIndexId() != null) {
+			rtn = configurationService.getWarehouseEndpoint() + "/publication/" + pub.getIndexId();
 		}
 		return rtn;
 	}
-	
+
 }

--- a/src/main/java/gov/usgs/cida/pubs/busservice/intfc/IPublicationBusService.java
+++ b/src/main/java/gov/usgs/cida/pubs/busservice/intfc/IPublicationBusService.java
@@ -7,10 +7,10 @@ import java.util.Map;
 
 public interface IPublicationBusService {
 
-	String getIndexPage(Publication<?> pub);
+	String getWarehousePage(Publication<?> pub);
 
 	Integer getObjectCount(Map<String, Object> filters);
 
 	List<Publication<?>> getObjects(Map<String, Object> filters);
-	
+
 }

--- a/src/main/java/gov/usgs/cida/pubs/transform/CrossrefTransformer.java
+++ b/src/main/java/gov/usgs/cida/pubs/transform/CrossrefTransformer.java
@@ -149,8 +149,7 @@ public class CrossrefTransformer extends Transformer {
 				boolean isNumberedSeries = PubsUtils.isUsgsNumberedSeries(pub.getPublicationSubtype());
 				model.put("isNumberedSeries", isNumberedSeries);
 
-				String indexPage = pubBusService.getIndexPage(pub);
-				model.put("indexPage", indexPage);
+				model.put("warehousePage", pubBusService.getWarehousePage(pub));
 
 				model.put("pubContributors", contributors);
 

--- a/src/main/resources/templates/crossref/body.ftlx
+++ b/src/main/resources/templates/crossref/body.ftlx
@@ -80,7 +80,7 @@
 				</#if>
 				<doi_data>
 					<doi>${pub.doi}</doi>
-					<resource>${indexPage}</resource>
+					<resource>${warehousePage}</resource>
 				</doi_data>
 			</content_item>
 		</report-paper>

--- a/src/test/java/gov/usgs/cida/pubs/busservice/PublicationBusServiceTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/busservice/PublicationBusServiceTest.java
@@ -72,38 +72,15 @@ public class PublicationBusServiceTest extends BaseTest {
 	}
 
 	@Test
-	public void getIndexPageTest() {
-		assertEquals("", service.getIndexPage(null));
+	public void getWarehousePageTest() {
+		assertEquals("", service.getWarehousePage(null));
 
 		MpPublication pub = new MpPublication();
-		assertEquals("", service.getIndexPage(pub));
+		assertEquals("", service.getWarehousePage(pub));
 		
 		pub.setIndexId("abcdef123");
 		String newUrl = configurationService.getWarehouseEndpoint()+"/publication/abcdef123";
-		assertEquals(newUrl, service.getIndexPage(pub));
-		
-		Collection<PublicationLink<?>> links = new ArrayList<>();
-		pub.setLinks(links);
-		assertEquals(newUrl, service.getIndexPage(pub));
+		assertEquals(newUrl, service.getWarehousePage(pub));
 
-		PublicationLink<?> link = new MpPublicationLink();
-		links.add(link);
-		assertEquals(newUrl, service.getIndexPage(pub));
-
-		link.setUrl("xyz");
-		assertEquals(newUrl, service.getIndexPage(pub));
-
-		LinkType linkType = new LinkType();
-		linkType.setId(LinkType.THUMBNAIL);
-		link.setLinkType(linkType);
-		assertEquals(newUrl, service.getIndexPage(pub));
-
-		PublicationLink<?> link2 = new MpPublicationLink();
-		LinkType linkType2 = new LinkType();
-		linkType2.setId(LinkType.INDEX_PAGE);
-		link2.setLinkType(linkType2);
-		link2.setUrl("http://pubs.usgs.gov/of/2013/1259/");
-		links.add(link2);
-		assertEquals("http://pubs.usgs.gov/of/2013/1259/", service.getIndexPage(pub));
 	}
 }

--- a/src/test/java/gov/usgs/cida/pubs/transform/CrossrefTransformerIT.java
+++ b/src/test/java/gov/usgs/cida/pubs/transform/CrossrefTransformerIT.java
@@ -225,7 +225,7 @@ public class CrossrefTransformerIT extends BaseIT {
 		assertNotNull(output);
 		assertTrue(0 < output.length());
 		assertWellFormed(output);
-		String expected = harmonizeXml(testOneUnNumberedSeriesXml);
+		String expected = harmonizeXml(updateWarehouseEndpoint(testOneUnNumberedSeriesXml));
 		String actual = harmonizeXml(output);
 		assertEquals(expected, actual);
 	}
@@ -243,7 +243,7 @@ public class CrossrefTransformerIT extends BaseIT {
 		assertNotNull(output);
 		assertTrue(0 < output.length());
 		assertWellFormed(output);
-		String expected = harmonizeXml(testOneNumberedSeriesXml);
+		String expected = harmonizeXml(updateWarehouseEndpoint(testOneNumberedSeriesXml));
 		String actual = harmonizeXml(output);
 		assertEquals(expected, actual);
 	}
@@ -276,9 +276,15 @@ public class CrossrefTransformerIT extends BaseIT {
 		assertNotNull(output);
 		assertTrue(0 < output.length());
 		assertWellFormed(output);
-		String expected = harmonizeXml(testOneNumberedSeriesXml);
+		String expected = harmonizeXml(updateWarehouseEndpoint(testOneNumberedSeriesXml));
 		String actual = harmonizeXml(output);
 		assertEquals(expected, actual);
+	}
+
+	private String updateWarehouseEndpoint(String xml) {
+		String updated = xml;
+		updated = updated.replace("{WarehouseEndpoint}", configurationService.getWarehouseEndpoint());
+		return updated;
 	}
 
 }

--- a/src/test/resources/testResult/testOneNumberedSeriesPub.xml
+++ b/src/test/resources/testResult/testOneNumberedSeriesPub.xml
@@ -55,7 +55,7 @@
                 </pages>
                 <doi_data>
                     <doi>10.3133/ofr20131259</doi>
-                    <resource>http://pubs.usgs.gov/of/2013/1259/</resource>
+                    <resource>{WarehouseEndpoint}/publication/numbered</resource>
                 </doi_data>
             </content_item>
         </report-paper>

--- a/src/test/resources/testResult/testOneUnNumberedSeriesPub.xml
+++ b/src/test/resources/testResult/testOneUnNumberedSeriesPub.xml
@@ -46,7 +46,7 @@
                 </pages>
                 <doi_data>
                     <doi>10.3133/ofr20131259</doi>
-                    <resource>http://pubs.usgs.gov/of/2013/1259/</resource>
+                    <resource>{WarehouseEndpoint}/publication/unnumbered</resource>
                 </doi_data>
             </content_item>
         </report-paper>


### PR DESCRIPTION
…just link to the pubs warehouse)

  In PublicationBusService, replaced getIndexPage(0 with getWarehousePage()
  Updated CrossrefTransforme to set warehousePage field using getWarehousePage()
  Updated body.ftlx to use ${warehousePage} for the resource tag.
  Updated test result resources