### PR TITLE
The person lookup response must contain id and text properties

### DIFF
--- a/src/main/java/gov/usgs/cida/pubs/domain/Contributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/Contributor.java
@@ -19,13 +19,13 @@ public class Contributor<D> extends BaseDomain<Contributor<D>> {
 	private static IDao<Contributor<?>> contributorDao;
 
 	@JsonProperty("corporation")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@NotNull
 	//TODO cross-field validations
 	protected Boolean corporation;
 
 	@JsonProperty("usgs")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@NotNull
 	//TODO cross-field validations
 	protected Boolean usgs;

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -39,13 +39,13 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private static IPersonContributorDao personContributorDao;
 
 	@JsonProperty("family")
-	@JsonView({View.PW.class, View.Lookup.class})
+	@JsonView(View.PW.class)
 	@NotNull
 	@Length(min=1, max=40)
 	private String family;
 
 	@JsonProperty("given")
-	@JsonView({View.PW.class, View.Lookup.class})
+	@JsonView(View.PW.class)
 	@Length(min=0, max=40)
 	private String given;
 
@@ -55,7 +55,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private String suffix;
 
 	@JsonProperty("email")
-	@JsonView({View.PW.class, View.Lookup.class})
+	@JsonView(View.PW.class)
 	@Length(min=0, max=400)
 	@Email
 	private String email;
@@ -67,7 +67,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private String orcid;
 
 	@JsonProperty("affiliations")
-	@JsonView({View.PW.class, View.Lookup.class})
+	@JsonView(View.PW.class)
 	private Set<Affiliation<? extends Affiliation<?>>> affiliations;
 
 	@JsonProperty("preferred")
@@ -111,7 +111,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	}
 
 	@JsonProperty("orcid")
-	@JsonView({View.PW.class, View.Lookup.class})
+	@JsonView(View.PW.class)
 	public String getDenormalizeOrcid() {
 		return DataNormalizationUtils.denormalizeOrcid(orcid);
 	}

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -39,13 +39,13 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private static IPersonContributorDao personContributorDao;
 
 	@JsonProperty("family")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@NotNull
 	@Length(min=1, max=40)
 	private String family;
 
 	@JsonProperty("given")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@Length(min=0, max=40)
 	private String given;
 
@@ -55,7 +55,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private String suffix;
 
 	@JsonProperty("email")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@Length(min=0, max=400)
 	@Email
 	private String email;
@@ -67,7 +67,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private String orcid;
 
 	@JsonProperty("affiliations")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	private Set<Affiliation<? extends Affiliation<?>>> affiliations;
 
 	@JsonProperty("preferred")
@@ -111,7 +111,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	}
 
 	@JsonProperty("orcid")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	public String getDenormalizeOrcid() {
 		return DataNormalizationUtils.denormalizeOrcid(orcid);
 	}

--- a/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
+++ b/src/main/java/gov/usgs/cida/pubs/domain/PersonContributor.java
@@ -39,23 +39,23 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private static IPersonContributorDao personContributorDao;
 
 	@JsonProperty("family")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@NotNull
 	@Length(min=1, max=40)
 	private String family;
 
 	@JsonProperty("given")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@Length(min=0, max=40)
 	private String given;
 
 	@JsonProperty("suffix")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@Length(min=0, max=40)
 	private String suffix;
 
 	@JsonProperty("email")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	@Length(min=0, max=400)
 	@Email
 	private String email;
@@ -67,7 +67,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	private String orcid;
 
 	@JsonProperty("affiliations")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	private Set<Affiliation<? extends Affiliation<?>>> affiliations;
 
 	@JsonProperty("preferred")
@@ -111,7 +111,7 @@ public class PersonContributor<D> extends Contributor<PersonContributor<D>> impl
 	}
 
 	@JsonProperty("orcid")
-	@JsonView(View.PW.class)
+	@JsonView({View.PW.class, View.Lookup.class})
 	public String getDenormalizeOrcid() {
 		return DataNormalizationUtils.denormalizeOrcid(orcid);
 	}

--- a/src/main/java/gov/usgs/cida/pubs/json/View.java
+++ b/src/main/java/gov/usgs/cida/pubs/json/View.java
@@ -5,7 +5,7 @@ public class View {
 	public interface Base {}
 
 	public interface Lookup extends Base {}
-	
+
 	public interface PW extends Base {}
 	
 	public interface MP extends PW {}

--- a/src/main/java/gov/usgs/cida/pubs/webservice/LookupMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/LookupMvcService.java
@@ -250,7 +250,7 @@ public class LookupMvcService extends MvcService<PublicationType> {
 	@ApiResponses(value={
 			@ApiResponse(code=HttpStatus.SC_BAD_REQUEST, message="Invalid query parameters provided.") }
 	)
-	@JsonView(View.Lookup.class)
+	@JsonView(View.PW.class)
 	public @ResponseBody Collection<Contributor<?>> getContributorsPeople(HttpServletRequest request, HttpServletResponse response,
 			PersonContributorFilterParams filterParams) {
 		Collection<Contributor<?>> rtn = new ArrayList<>();

--- a/src/main/java/gov/usgs/cida/pubs/webservice/LookupMvcService.java
+++ b/src/main/java/gov/usgs/cida/pubs/webservice/LookupMvcService.java
@@ -250,7 +250,7 @@ public class LookupMvcService extends MvcService<PublicationType> {
 	@ApiResponses(value={
 			@ApiResponse(code=HttpStatus.SC_BAD_REQUEST, message="Invalid query parameters provided.") }
 	)
-	@JsonView(View.PW.class)
+	@JsonView(View.Lookup.class)
 	public @ResponseBody Collection<Contributor<?>> getContributorsPeople(HttpServletRequest request, HttpServletResponse response,
 			PersonContributorFilterParams filterParams) {
 		Collection<Contributor<?>> rtn = new ArrayList<>();

--- a/src/test/java/gov/usgs/cida/pubs/webservice/LkupMvcServiceTest.java
+++ b/src/test/java/gov/usgs/cida/pubs/webservice/LkupMvcServiceTest.java
@@ -93,7 +93,7 @@ public class LkupMvcServiceTest extends BaseTest {
 	private JSONArray contributorJsonArray(PersonContributor<?> contributor) throws JSONException {
 		JSONObject json = new JSONObject();
 
-		json.put("contributorId", contributor.getId());
+		json.put("id", contributor.getId());
 		json.put("email", contributor.getEmail());
 		json.put("given", contributor.getGiven());
 		json.put("preferred", contributor.isPreferred());

--- a/src/test/java/gov/usgs/cida/pubs/webservice/LookupMvcServiceBuildDbIT.java
+++ b/src/test/java/gov/usgs/cida/pubs/webservice/LookupMvcServiceBuildDbIT.java
@@ -101,7 +101,7 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 		assertEquals(1, rtnAsJSONArray.length());
 
 		assertThat(rtnAsJSONArray,
-				sameJSONArrayAs(new JSONArray("[{\"id\":2,\"text\":\"US Geological Survey Ice Survey Team\"}]"))
+				sameJSONArrayAs(new JSONArray("[{\"id\":2,\"text\":\"US Geological Survey Ice Survey Team\", \"corporation\":true, \"usgs\":false}]"))
 						.allowingAnyArrayOrdering());
 	}
 
@@ -358,7 +358,7 @@ public class LookupMvcServiceBuildDbIT extends BaseIT {
 	private JSONArray contributorJsonArray(PersonContributor<?> contributor) throws JSONException {
 		JSONObject json = new JSONObject();
 
-		json.put("contributorId", contributor.getId());
+		json.put("id", contributor.getId());
 		json.put("email", contributor.getEmail());
 		json.put("given", contributor.getGiven());
 		json.put("preferred", contributor.isPreferred());


### PR DESCRIPTION
The original ticket PUBSTWO-1689 also extended the lookup response to contain other fields. These fields have been retained.